### PR TITLE
H_eff computation

### DIFF
--- a/mtj/calc_Heff.py
+++ b/mtj/calc_Heff.py
@@ -53,6 +53,6 @@ def calc_Heff(
     H_d = -M_s*(np.matmul(N, m))
 
     # STT term
-    H_STT = a_para*np.cross(m,p) - a_orth*p
+    H_STT = a_para*V*np.cross(m,p) - a_orth*p*(V**2)
 
     return H_mca + H_app + H_d + H_STT

--- a/mtj/calc_Heff.py
+++ b/mtj/calc_Heff.py
@@ -1,10 +1,15 @@
 import numpy as np
 import numpy.typing as ntp
+import scipy.constants as cst
 
 
 def calc_Heff(
     m: ntp.NDArray[np.float64],
-    # More parameters goes here
+    K_u: float,
+    M_s: float,
+    u_k: ntp.NDArray[np.float64],
+    H_app: ntp.NDArray[np.float64],
+    N: ntp.NDArray[np.float64]
 ) -> ntp.NDArray[np.float64]:
     """Calculates the effective field
 
@@ -12,13 +17,27 @@ def calc_Heff(
     ----------
         m: array_like
             Current magnetization as a Numpy array of floats with shape (3,).
+        K_u: float
+            First order crystal anisotropy constant (J/m^3)
+        M_s: float
+            Saturation magnetization module (A/m)
+        u_k: array_like
+            Direction of easy axis as a Numpy array of floats with shape (3,).
+        H_app: array_like
+            Externally applied magnetic field as a Numpy array of floats with shape (3,).
+        N: array_like
+            Demagnetization tensor as a Numpy array of floats with shape (3,3).
+
 
     Returns
     -------
         H_eff: array_like
             The effective field as a Numpy array of floats with shape (3,).
     """
+    # magneto-crystalline anisotropy term
+    H_mca = 2*K_u/(cst.mu_0*M_s)*np.dot(u_k, m)*u_k
 
-    # The implementation goes here
+    # demagnetization energy term
+    H_d = -M_s*(np.matmul(N, m))
 
-    return np.array([0, 0, 0])  # TODO Replace this after implementing function
+    return H_mca + H_app + H_d

--- a/mtj/calc_Heff.py
+++ b/mtj/calc_Heff.py
@@ -8,6 +8,10 @@ def calc_Heff(
     K_u: float,
     M_s: float,
     u_k: ntp.NDArray[np.float64],
+    p: ntp.NDArray[np.float64],
+    a_para: float,
+    a_orth: float,
+    V: float,
     H_app: ntp.NDArray[np.float64],
     N: ntp.NDArray[np.float64]
 ) -> ntp.NDArray[np.float64]:
@@ -18,11 +22,19 @@ def calc_Heff(
         m: array_like
             Current magnetization as a Numpy array of floats with shape (3,).
         K_u: float
-            First order crystal anisotropy constant (J/m^3)
+            First order crystal anisotropy constant (J/m^3).
         M_s: float
-            Saturation magnetization module (A/m)
+            Saturation magnetization module (A/m).
         u_k: array_like
             Direction of easy axis as a Numpy array of floats with shape (3,).
+        p: array_like
+            Spin polarization unit vector as a Numpy array of floats with shape (3,).
+        a_para: float
+            Parallel STT coefficient.
+        a_ortho: float
+            Orthogonal STT coefficient.
+        V: float
+            Applied voltage (V).
         H_app: array_like
             Externally applied magnetic field as a Numpy array of floats with shape (3,).
         N: array_like
@@ -40,4 +52,7 @@ def calc_Heff(
     # demagnetization energy term
     H_d = -M_s*(np.matmul(N, m))
 
-    return H_mca + H_app + H_d
+    # STT term
+    H_STT = a_para*np.cross(m,p) - a_orth*p
+
+    return H_mca + H_app + H_d + H_STT

--- a/mtj/llg_heun.py
+++ b/mtj/llg_heun.py
@@ -4,30 +4,22 @@ import numpy.typing as ntp
 from mtj.constants import GYROMAGNETIC_RATIO
 
 
-def LLG_rhs(p_vec, m_vec, H_vec, gamma0, alpha, a_perp, a_par):
+def LLG_rhs(m_vec, H_vec, gamma0, alpha):
     prefactor = -gamma0 / (1 + alpha**2)
 
     mxH = np.cross(m_vec, H_vec)
     mxmxH = np.cross(m_vec, mxH)
     torque_llg = prefactor * (mxH + alpha * mxmxH)
 
-    # STT terms
-    mxp = np.cross(m_vec, p_vec)
-    mxmxp = np.cross(m_vec, mxp)
-    stt_term = -gamma0 * a_par * mxmxp + gamma0 * a_perp * mxp
-
-    return torque_llg + stt_term
+    return torque_llg
 
 
 def LLG_Heun(
     m_i: ntp.NDArray[np.float64],
-    p_i: ntp.NDArray[np.float64],
     H_eff: ntp.NDArray[np.float64],
     H_th: ntp.NDArray[np.float64],
     dt: float,
     alpha: float,
-    a_perp: float,
-    a_par: float,
     # TODO Verify this value
     gamma0: float = 2.21e5,  # gyromagnetic ratio in (m/As)
 ) -> ntp.NDArray[np.float64]:
@@ -39,18 +31,14 @@ def LLG_Heun(
             The next time step magnetization as a NumPy array of floats with shape (3,).
     """
 
-    # Normalize input vectors in place
-    m_i = m_i / np.linalg.norm(m_i)
-    p_i = p_i / np.linalg.norm(p_i)
-
     H_tot = H_eff + H_th
 
     # Heun's method
-    k1 = LLG_rhs(p_i, m_i, H_tot, gamma0, alpha, a_perp, a_par)
+    k1 = LLG_rhs(m_i, H_tot, gamma0, alpha)
     m_temp = m_i + dt * k1
     m_temp /= np.linalg.norm(m_temp)  # keep magnetization normalized
 
-    k2 = LLG_rhs(p_i, m_temp, H_tot, gamma0, alpha, a_perp, a_par)
+    k2 = LLG_rhs( m_temp, H_tot, gamma0, alpha)
     m_next = m_i + (dt / 2) * (k1 + k2)
     m_next /= np.linalg.norm(m_next)  # renormalize
 

--- a/mtj/main.py
+++ b/mtj/main.py
@@ -45,6 +45,7 @@ def main() -> None:
         print("Thermal Field Vector H_th:", H_th)
         # Calculate the effective field
         H_eff = calc_Heff(m[i],
+                          K_u,
                           M_s,
                           u_k,
                           p,

--- a/mtj/main.py
+++ b/mtj/main.py
@@ -32,22 +32,35 @@ def main() -> None:
     a_par = 1e-3  # A_parallel(V), in (T)
     a_perp = 2e-4  # A_perpendicular(V), in (T)
 
+    # dummy values for Heff
+    K_u = 0 # crystal anisotropy constant
+    M_s = 1 # saturation magnetization module (A/m)
+    u_k = np.array([0, 0, 1]) # easy axis
+    Volt = 0 # STT voltage applied (V)
+    H_app = np.array([0, 0, 0]) # applied field (A/m)
+    N = np.array([[1,0,0],[0,1,0],[0,0,1]]) # demagnetization tensor
+
     for i, t in enumerate(time_series[:-1]):
         H_th = compute_thermal_field(alpha, T, Ms, V, dt)
         print("Thermal Field Vector H_th:", H_th)
         # Calculate the effective field
-        H_eff = calc_Heff(np.array([1, 0, 0]))
+        H_eff = calc_Heff(m[i],
+                          M_s,
+                          u_k,
+                          p,
+                          a_par,
+                          a_perp,
+                          Volt,
+                          H_app,
+                          N)
 
         # Calculate the magnetization for the next time step
         m[i + 1] = LLG_Heun(
             m[i],
-            p,
             H_eff,
             H_th,
             dt,
-            alpha,
-            a_perp,
-            a_par,
+            alpha
         )
 
     np.savetxt(output_file_path, m, delimiter=",")


### PR DESCRIPTION
I implemented the function which computes the effective field in module calc_Heff. It includes:
- **Applied field**
- **Demagnetizing field** (shape anisotropy)
- **Crystal anisotropy**

It does NOT include STT coupling since Lina wanted to implement it, but eventually we could add it in this same module. According to the reference papers with the equations it could be modified to account also for local exchange with nonuniform magnetization (file "micromagnetism-L-Buda_Prejbeanu.pdf", equation 15), but only for the future if we'll have time.

I hope it's well documented, I made explicit also the measurement units expected.